### PR TITLE
GEN-245 Header Styling

### DIFF
--- a/src/components/Header.stories.tsx
+++ b/src/components/Header.stories.tsx
@@ -12,6 +12,16 @@ export const Default = () => (
     </div>
 );
 
+export const LongURL = () => (
+    <div style={{ width: '370px' }}>
+        <Header
+            to='0xdd0ba6a96Aae2A2031536eD255d77459dE937fD2'
+            network='Ethereum Mainnet'
+            url='https://github.com/mackbowes/metl-ui/blob/667786f4bf6a6b8c4cb23ca72e18efd526b2a371/utils/web3modal.js'
+        />
+    </div>
+);
+
 export const RisksToggle = () => {
     const [severity, setSeverity] = useState<Severity | undefined>('NONE');
 

--- a/src/components/Header.styles.tsx
+++ b/src/components/Header.styles.tsx
@@ -29,6 +29,12 @@ export const InfoList = styled.div`
     gap: 12px;
 `;
 
+export const URLLink = styled(Link)`
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`;
+
 export const Risk = styled.div<RiskProps>`
     display: flex;
     align-items: center;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import * as Types from '../types/api';
 
 import { Copy } from './UI/Copy';
-import { Link } from './UI/Link';
 
 import { riskIcons } from '../shared/theme';
 import * as Styled from './Header.styles';

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,12 +26,14 @@ const severityTitle: { [key in Types.Severity]: string } = {
 export function Header({ url, network, to, severity }: HeaderProps) {
     const SeverityIcon = severity ? riskIcons[severity] : undefined;
 
+    const formattedAddress = (to: string) => `${to.slice(0, 8)}...${to.slice(-4)}`.toUpperCase();
+
     return (
         <Styled.Container severity={severity}>
             {url && (
-                <Link href={url} target='_blank' rel='noreferrer'>
+                <Styled.URLLink href={url} target='_blank' rel='noreferrer'>
                     {url}
-                </Link>
+                </Styled.URLLink>
             )}
 
             <Styled.InfoList>
@@ -41,12 +43,10 @@ export function Header({ url, network, to, severity }: HeaderProps) {
                 </Styled.Info.Group>
                 <Styled.Info.Group>
                     <Styled.Info.Title>Contract address</Styled.Info.Title>
-                    <Styled.Info.Value>{to}</Styled.Info.Value>
-                    <Styled.Info.Copy>
-                        <Copy text={to} size='14'>
-                            copy address
-                        </Copy>
-                    </Styled.Info.Copy>
+                    <Styled.Info.Value>
+                        {formattedAddress(to)} <Copy text={to} size='14' />
+                    </Styled.Info.Value>
+                    <Styled.Info.Copy></Styled.Info.Copy>
                 </Styled.Info.Group>
             </Styled.InfoList>
             <Styled.Fill />


### PR DESCRIPTION
1. Fixed contract three dots
2. Moved copy button
3. Improved URL rendering (though currently not displayed)

<img width="381" alt="Screenshot 2023-02-13 at 13 13 33" src="https://user-images.githubusercontent.com/120090466/218443211-bda7882c-3de6-433d-8458-014c4b49d6c0.png">
