### PR TITLE
GEN-282 Bug Fix 'getActiveTabUrl' is broken

### DIFF
--- a/src/helpers/getActiveTab.ts
+++ b/src/helpers/getActiveTab.ts
@@ -1,0 +1,12 @@
+import * as storage from '../shared/storage';
+
+export async function getActiveTabUrl() {
+    let url = '';
+    if (await storage.getEnableUrlAnalysis()) {
+        const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+        if (tabs.length > 0) {
+            url = tabs[0].url || '';
+        }
+    }
+    return url;
+}

--- a/src/helpers/showPopup.ts
+++ b/src/helpers/showPopup.ts
@@ -1,4 +1,5 @@
 import { TransactionEvent } from '../types/internal';
+import { getActiveTabUrl } from './getActiveTab';
 
 const WALLET_NOTIFICATION_WIDTH = 360;
 
@@ -27,9 +28,10 @@ async function getPosition() {
 export const showPopup = async (chainId: string, event: TransactionEvent) => {
     const { triggerType, requestType, payload } = event;
     const { top, left } = await getPosition();
+    const url = await getActiveTabUrl();
 
     if (triggerType === 'request' && requestType === 'eth_sendTransaction') {
-        const data: Record<string, string> = { chainId, ...(payload as Record<string, string>) };
+        const data: Record<string, string> = { url, chainId, ...(payload as Record<string, string>) };
         const searchParams = new URLSearchParams(data);
         const popupUrl = `walletpopup.html?${searchParams.toString()}`;
 

--- a/src/pages/Popup/index.tsx
+++ b/src/pages/Popup/index.tsx
@@ -10,6 +10,7 @@ import { ContentDecoder } from '../../components/ContentDecoder';
 import { ErrorBoundary } from '../../components/CriticalError';
 
 import { fetchAnalyze, fetchDescription } from '../../shared/api';
+import { getActiveTabUrl } from '../../helpers/getActiveTab';
 import * as Styled from './index.styled';
 
 import '../../shared/reset.css';
@@ -21,7 +22,7 @@ function Panel() {
     const [to, setTo] = useState('');
     const [chainId, setChainId] = useState('0x1');
     const descriptionResult = useAsyncCallback(async (chainId, to) => fetchDescription(chainId, to));
-    const analyzeResult = useAsyncCallback(async (chainId, to) => fetchAnalyze(chainId, to));
+    const analyzeResult = useAsyncCallback(async (chainId, to, url) => fetchAnalyze(chainId, to, url));
 
     useEffect(() => {
         logPageView('Popup');
@@ -30,8 +31,9 @@ function Panel() {
     async function handleClick(chainId: string, to: string) {
         setChainId(chainId);
         setTo(to);
+        const url = await getActiveTabUrl();
         descriptionResult.execute(chainId, to);
-        analyzeResult.execute(chainId, to);
+        analyzeResult.execute(chainId, to, url);
         logSearchClick(to, chainId);
     }
     const chatError =

--- a/src/pages/WalletPopup/index.tsx
+++ b/src/pages/WalletPopup/index.tsx
@@ -19,8 +19,9 @@ function Panel() {
     const urlSearchParams = new URLSearchParams(window.location.search);
     const to = urlSearchParams.get('to') || '';
     const chainId: string = urlSearchParams.get('chainId') || '0x1';
+    const url: string = urlSearchParams.get('url') || '';
     const descriptionResult = useAsync(fetchDescription, [chainId, to]);
-    const analyzeResult = useAsync(fetchAnalyze, [chainId, to]);
+    const analyzeResult = useAsync(fetchAnalyze, [chainId, to, url]);
 
     useEffect(() => {
         logPageView('Wallet Popup');

--- a/src/shared/api.tsx
+++ b/src/shared/api.tsx
@@ -1,30 +1,17 @@
 import axios, { AxiosError } from 'axios';
 import { ChatResponse, EngineResponse, ErrorResponse } from '../types/api';
 import { logException } from '../shared/logs';
-import * as storage from '../shared/storage';
 
 const BASE_URL = process.env.API_SERVER;
 const API_KEY = process.env.API_KEY;
 
-async function maybeGetActiveTabUrl(): Promise<string> {
-    const enableUrlAnalysis = await storage.getEnableUrlAnalysis();
-    if (!enableUrlAnalysis) {
-        return Promise.resolve('');
-    }
-    return new Promise(function (resolve, reject) {
-        chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-            if (tabs.length > 0) {
-                resolve(tabs[0].url || '');
-            } else {
-                reject('No active tab found');
-            }
-        });
-    });
-}
-
-async function _fetchFunction<ResponseType>(page: string, chainId: string, to: string): Promise<ResponseType> {
+async function _fetchFunction<ResponseType>(
+    page: string,
+    chainId: string,
+    to: string,
+    url: string
+): Promise<ResponseType> {
     try {
-        const url = await maybeGetActiveTabUrl();
         const response = await axios({
             method: 'post',
             url: `${BASE_URL}/${page}`,
@@ -56,9 +43,9 @@ async function _fetchFunction<ResponseType>(page: string, chainId: string, to: s
 }
 
 export const fetchDescription = async (chainId: string, to: string): Promise<ChatResponse> => {
-    return _fetchFunction<ChatResponse>('chat', chainId, to);
+    return _fetchFunction<ChatResponse>('chat', chainId, to, '');
 };
 
-export const fetchAnalyze = async (chainId: string, to: string): Promise<EngineResponse> => {
-    return _fetchFunction<EngineResponse>('analyze', chainId, to);
+export const fetchAnalyze = async (chainId: string, to: string, url: string): Promise<EngineResponse> => {
+    return _fetchFunction<EngineResponse>('analyze', chainId, to, url);
 };


### PR DESCRIPTION
# Issue: 
Turns out 'getActiveTabUrl' returns the extensions url instead of the window that poped the Tx

# Fix:
Run the query before we popup the window.

# Test:
Make sure we send the proper url for both scenarios

<img width="669" alt="Screenshot 2023-02-28 at 9 51 00" src="https://user-images.githubusercontent.com/119320418/221788220-b84c9de6-db23-44d2-9d4e-7b4f3bf0b93b.png">
