### PR TITLE
Missing polygon name

### DIFF
--- a/src/components/NetworkSelector.tsx
+++ b/src/components/NetworkSelector.tsx
@@ -21,6 +21,7 @@ export const networkMapping: { [key: string]: string } = {
     '0x1': 'Ethereum',
     '0x5': 'Goerli',
     '0x0xaa36a7': 'Sepolia',
+    '137': 'Polygon',
     '80001': 'Polygon Mumbai',
     '56': 'BSC',
     '42161': 'Arbitrum',


### PR DESCRIPTION
Fixed missing polygon name on the result's header:

<img width="428" alt="Screenshot 2023-04-03 at 13 04 40" src="https://user-images.githubusercontent.com/120090466/229479260-49e0abed-e758-4754-95fa-71e55ea6a54b.png">
