### PR TITLE
GEN-238-Disable_URL_check_for_manual_address_search

### DIFF
--- a/src/pages/Popup/PopupPanel.tsx
+++ b/src/pages/Popup/PopupPanel.tsx
@@ -33,9 +33,8 @@ export function PopupPanel({ hideAlpha = false, hideSettings = false, standalone
     async function handleClick(chainId: string, to: string) {
         setChainId(chainId);
         setTo(to);
-        const url = standalone ? undefined : await getActiveTabUrl();
         descriptionResult.execute(chainId, to);
-        analyzeResult.execute(chainId, to, url);
+        analyzeResult.execute(chainId, to, undefined); // disable URL check for manual address search
         logSearchClick(to, chainId);
     }
 


### PR DESCRIPTION
verified with inspect, make sure 'browser_data' is empty.
<img width="655" alt="Screenshot 2023-05-11 at 15 40 44" src="https://github.com/blockfence-io/extension/assets/119320418/4c7ccddd-02e6-4415-88d9-c3c1b18c189a">
