### PR TITLE
GEN-432-Dont-show-transaction-simulation-when-there-s-nothing-to-show-like-when-searching-for-an-address

### DIFF
--- a/src/components/ContentDecoder.tsx
+++ b/src/components/ContentDecoder.tsx
@@ -25,10 +25,8 @@ interface ContentDecoderProps {
 }
 
 const shouldShowSimulation = (transaction_simulation?: TransactionSimulation) => {
-    return (transaction_simulation?.outgoing_transaction.amount &&
-    transaction_simulation?.outgoing_transaction.symbol) ||
-    (transaction_simulation?.incoming_transaction.amount &&
-        transaction_simulation?.incoming_transaction.symbol)
+    return transaction_simulation?.outgoing_transaction.symbol.length != 0 ||
+        transaction_simulation?.incoming_transaction.symbol.length != 0
 }
 
 export function ContentDecoder({ to, chainId = '1', descriptionResult, analyzeResult, url }: ContentDecoderProps) {


### PR DESCRIPTION
The bug is that when manually opening the extension and searching for an address, there would appear a 0 that seems out of place (because it is). I've fixed the function that decides wether to show the transaction simulation section or not.
## Popup:
<img width="512" alt="image" src="https://github.com/blockfence-io/extension/assets/130892418/e7062fd8-a585-443f-b92d-8daca1947f6a">

## Manual search:
<img width="376" alt="image" src="https://github.com/blockfence-io/extension/assets/130892418/265924a8-a316-4776-ba8c-5e920a065286">
