### PR TITLE
GEN-435-Fix-extension-to-not-show-unexpected-USD-values

### DIFF
--- a/src/components/Simulation.tsx
+++ b/src/components/Simulation.tsx
@@ -15,6 +15,10 @@ const getAmountString = (amount?: number, symbol?: string) => {
     return amount ? `${getFormattedNumber(amount)} ${symbol}` : "0";
 }
 
+const shouldShowUSD = (amount?: number) => {
+    return amount && amount > 0
+}
+
 export function Simulation({ simulation, defaultState = false }: SimulationProps) {
     return (
         
@@ -25,7 +29,9 @@ export function Simulation({ simulation, defaultState = false }: SimulationProps
                     <Styled.CenteredIconWithText>
                         {getAmountString(simulation?.outgoing_transaction.amount, simulation?.outgoing_transaction.symbol)}
                         {simulation?.outgoing_transaction.logo && <img src={simulation.outgoing_transaction.logo} width='18' />}
-                        {simulation?.outgoing_transaction.usd && <div>~${getFormattedNumber(simulation?.outgoing_transaction.usd)}</div>}
+                        {shouldShowUSD(simulation?.outgoing_transaction.usd) == true &&
+                            <div>~${getFormattedNumber(simulation?.outgoing_transaction.usd)}</div>
+                        }
                     </Styled.CenteredIconWithText>
                     
                 </Styled.SectionContainer>
@@ -34,7 +40,9 @@ export function Simulation({ simulation, defaultState = false }: SimulationProps
                     <Styled.CenteredIconWithText>
                         {getAmountString(simulation?.incoming_transaction.amount, simulation?.incoming_transaction.symbol)}
                         {simulation?.incoming_transaction.logo && <img src={simulation.incoming_transaction.logo} width='18' />}
-                        {simulation?.incoming_transaction.usd && <div>~${getFormattedNumber(simulation?.incoming_transaction.usd)}</div>}
+                        {shouldShowUSD(simulation?.incoming_transaction.usd) == true &&
+                            <div>~${getFormattedNumber(simulation?.incoming_transaction.usd)}</div>
+                        }
                     </Styled.CenteredIconWithText>
                     
                 </Styled.SectionContainer>

--- a/src/components/Simulation.tsx
+++ b/src/components/Simulation.tsx
@@ -30,7 +30,7 @@ export function Simulation({ simulation, defaultState = false }: SimulationProps
                         {getAmountString(simulation?.outgoing_transaction.amount, simulation?.outgoing_transaction.symbol)}
                         {simulation?.outgoing_transaction.logo && <img src={simulation.outgoing_transaction.logo} width='18' />}
                         {shouldShowUSD(simulation?.outgoing_transaction.usd) == true &&
-                            <div>~${getFormattedNumber(simulation?.outgoing_transaction.usd)}</div>
+                            <div>${getFormattedNumber(simulation?.outgoing_transaction.usd)}</div>
                         }
                     </Styled.CenteredIconWithText>
                     
@@ -41,7 +41,7 @@ export function Simulation({ simulation, defaultState = false }: SimulationProps
                         {getAmountString(simulation?.incoming_transaction.amount, simulation?.incoming_transaction.symbol)}
                         {simulation?.incoming_transaction.logo && <img src={simulation.incoming_transaction.logo} width='18' />}
                         {shouldShowUSD(simulation?.incoming_transaction.usd) == true &&
-                            <div>~${getFormattedNumber(simulation?.incoming_transaction.usd)}</div>
+                            <div>${getFormattedNumber(simulation?.incoming_transaction.usd)}</div>
                         }
                     </Styled.CenteredIconWithText>
                     
@@ -49,7 +49,7 @@ export function Simulation({ simulation, defaultState = false }: SimulationProps
             </Styled.Container>
             {/* <Styled.CenteredIconWithText>
                 <div>Gas used: {getAmountString(simulation?.gas_used, simulation?.gas_symbol)}</div>
-                {simulation?.gas_usd && <div>~${getFormattedNumber(simulation?.gas_usd)}</div>}
+                {simulation?.gas_usd && <div>${getFormattedNumber(simulation?.gas_usd)}</div>}
             </Styled.CenteredIconWithText> */}
         </Collapsable>
     );

--- a/src/helpers/getFormattedNumber.ts
+++ b/src/helpers/getFormattedNumber.ts
@@ -1,4 +1,7 @@
-export function getFormattedNumber(input: number, defaultDigitsAfterDecimalPoint = 3): number {
+export function getFormattedNumber(input?: number, defaultDigitsAfterDecimalPoint = 3): number {
+    if (input === undefined) {
+        return 0
+    }
     const numString = input.toString();
 
     if (!numString.includes(".")) {


### PR DESCRIPTION
## Before fix:
![image](https://github.com/blockfence-io/extension/assets/130892418/932730ae-1b85-4b5a-84c0-91eb1bc8ea3e)

## After fix:
<img width="512" alt="image" src="https://github.com/blockfence-io/extension/assets/130892418/23bb7349-4e58-4b7c-b345-2f235bcfc8f1">
